### PR TITLE
Add explicit dependency on underscore

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,6 +9,7 @@ Npm.depends({github: '0.2.2'});
 
 Package.on_use(function (api) {
   api.versionsFrom("METEOR-CORE@0.9.0-atm");
+  api.use(['underscore'], ['client', 'server']);
   api.export('GitHub');
 
   api.add_files('github-api.js', 'server');


### PR DESCRIPTION
Underscore is needed, and if using this in another package (i.e. `api.use(['bruz:github-api'])`) we need to have it explicitly referenced in `package.js`.
